### PR TITLE
Character class developments and minor fixes

### DIFF
--- a/Warhammer_40k-_The_Long_War_W40k-TLW_Tyranids.rulebook
+++ b/Warhammer_40k-_The_Long_War_W40k-TLW_Tyranids.rulebook
@@ -79,6 +79,16 @@
             "failState": "pass"
           }
         }
+      },
+      "Wargear": {
+        "removed": {
+          "stats": {
+            "Warlord Trait 2": {}
+          }
+        }
+      },
+      "Warlord Trait": {
+        "text": ""
       }
     },
     "assetCatalog": {
@@ -117,6 +127,144 @@
       },
       "Bio-Morph§Wings": {
         "text": "A Tyranid Infantry or Monster unit with this Bio-Morph\nincreases their Movement (M) characteristic to 12”. It\ngains the Hammer of Wrath (1) and Deep strike special\nrules. The equipped model gains the Fly keyword."
+      },
+      "Character§Tervigon": {
+        "allowed": {
+          "items": [
+            "Model§Tervigon"
+          ]
+        },
+        "assets": {
+          "included": [
+            "Model§Tervigon"
+          ],
+          "traits": [
+            "Special Rule§Synapse",
+            "Special Rule§Shadow in the Warp",
+            "Special Rule§Brood Progenitor",
+            "Special Rule§Spawn Termagants",
+            "Special Rule§The Swarm Descends",
+            "Special Rule§Adaptive Physiology",
+            {
+              "item": "Special Rule§Hammer of Wrath",
+              "stats": {
+                "x": {
+                  "value": "1"
+                }
+              }
+            },
+            {
+              "item": "Special Rule§Psyker",
+              "stats": {
+                "x": {
+                  "value": "1"
+                }
+              }
+            },
+            "Special Rule§Regeneration",
+            "Special Rule§Move Through Cover"
+          ]
+        },
+        "keywords": {
+          "Unit Type": [
+            "Monster"
+          ],
+          "Keywords": [
+            "Character",
+            "Command",
+            "M41",
+            "Psyker",
+            "Synapse",
+            "Tyranids"
+          ],
+          "Role": [
+            "HQ"
+          ],
+          "Tags": [],
+          "Faction": [
+            "Tyranids"
+          ]
+        },
+        "stats": {
+          "Tervigon": {
+            "max": 1,
+            "min": 1,
+            "statType": "numeric",
+            "tracked": true,
+            "value": 0,
+            "visibility": "normal"
+          },
+          "Warlord Trait": {
+            "dynamic": true,
+            "ranks": {
+              "-": {
+                "order": 0
+              },
+              "Alien Cunning": {
+                "order": 1,
+                "traits": [
+                  {
+                    "trait": "Warlord Trait§Alien Cunning"
+                  }
+                ]
+              },
+              "Synaptic Linchpin": {
+                "order": 2,
+                "traits": [
+                  {
+                    "trait": "Warlord Trait§Synaptic Linchpin"
+                  }
+                ]
+              },
+              "Heightened Senses": {
+                "order": 3,
+                "traits": [
+                  {
+                    "trait": "Warlord Trait§Heightened Senses"
+                  }
+                ]
+              }
+            },
+            "statType": "rank",
+            "tracked": true,
+            "value": "-"
+          },
+          "Warlord Trait 2": {
+            "dynamic": true,
+            "ranks": {
+              "-": {
+                "order": 0
+              },
+              "Alien Cunning": {
+                "order": 1,
+                "traits": [
+                  {
+                    "trait": "Warlord Trait§Alien Cunning"
+                  }
+                ]
+              },
+              "Synaptic Linchpin": {
+                "order": 2,
+                "traits": [
+                  {
+                    "trait": "Warlord Trait§Synaptic Linchpin"
+                  }
+                ]
+              },
+              "Heightened Senses": {
+                "order": 3,
+                "traits": [
+                  {
+                    "trait": "Warlord Trait§Heightened Senses"
+                  }
+                ]
+              }
+            },
+            "statType": "rank",
+            "tracked": true,
+            "value": "-"
+          }
+        }
       },
       "Melee Weapon§Acid Maw": {
         "stats": {
@@ -893,10 +1041,6 @@
       "Model§Carnifex": {
         "assets": {
           "traits": [
-            {
-              "item": "Melee Weapon§Monstrous Scything Talons",
-              "quantity": 2
-            },
             "Wargear§Bonded Exoskeleton",
             "Special Rule§Shadow in the Warp",
             "Special Rule§The Swarm Descends",
@@ -2474,6 +2618,76 @@
           },
           "Wounds (W)": {
             "value": 1
+          }
+        }
+      },
+      "Model§Tervigon": {
+        "assets": {
+          "traits": [
+            "Ranged Weapon§Stinger Salvo",
+            "Wargear§Bonded Exoskeleton",
+            "Ranged Weapon§Smite"
+          ]
+        },
+        "stats": {
+          "Attacks (A)": {
+            "value": 3
+          },
+          "Ballistic Skill (BS)": {
+            "value": 3
+          },
+          "Initiative (I)": {
+            "value": 3
+          },
+          "Leadership (Ld)": {
+            "value": 9
+          },
+          "Loadout": {
+            "ranks": {
+              "Monstrous Scything Talons": {
+                "order": 0,
+                "traits": [
+                  {
+                    "trait": "Melee Weapon§Monstrous Scything Talons"
+                  }
+                ]
+              },
+              "Monstrous Crushing Claws": {
+                "order": 1,
+                "tracking": {
+                  "Points": 15
+                },
+                "traits": [
+                  {
+                    "trait": "Melee Weapon§Monstrous Crushing Claws"
+                  }
+                ]
+              }
+            },
+            "statType": "rank",
+            "value": "Monstrous Scything Talons",
+            "visibility": "normal"
+          },
+          "Movement (M)": {
+            "value": 8
+          },
+          "Points": {
+            "value": 120
+          },
+          "Save (Sv)": {
+            "value": 3
+          },
+          "Strength (S)": {
+            "value": 7
+          },
+          "Toughness (T)": {
+            "value": 8
+          },
+          "Weapon Skill (WS)": {
+            "value": 3
+          },
+          "Wounds (W)": {
+            "value": 5
           }
         }
       },
@@ -5247,7 +5461,22 @@
         },
         "keywords": {
           "Keywords": [
-            "Feeder"
+            "Character",
+            "Feeder",
+            "Fly",
+            "M41",
+            "Malanthrope",
+            "Synapse",
+            "Tyranids"
+          ],
+          "Role": [
+            "Elites"
+          ],
+          "Faction": [
+            "Tyranids"
+          ],
+          "Unit Type": [
+            "Infantry"
           ]
         },
         "stats": {
@@ -5398,6 +5627,15 @@
             "Mucolid Spore",
             "Tyranids",
             "Vanguard"
+          ],
+          "Role": [
+            "Fast Attack"
+          ],
+          "Faction": [
+            "Tyranids"
+          ],
+          "Unit Type": [
+            "Infantry"
           ]
         },
         "stats": {
@@ -5823,131 +6061,6 @@
             "tracked": true,
             "value": 0,
             "visibility": "normal"
-          }
-        }
-      },
-      "Unit§Tervigon": {
-        "allowed": {
-          "items": []
-        },
-        "assets": {
-          "included": [],
-          "traits": [
-            "Special Rule§Synapse",
-            "Special Rule§The Swarm Descends",
-            {
-              "item": "Special Rule§Hammer of Wrath",
-              "stats": {
-                "x": {
-                  "value": "1"
-                }
-              }
-            },
-            "Special Rule§Brood Progenitor",
-            "Special Rule§Spawn Termagants",
-            "Special Rule§Shadow in the Warp",
-            "Special Rule§Move Through Cover",
-            "Special Rule§Adaptive Physiology",
-            "Special Rule§Regeneration",
-            "Ranged Weapon§Stinger Salvo",
-            "Ranged Weapon§Smite",
-            "Wargear§Bonded Exoskeleton",
-            {
-              "item": "Special Rule§Psyker",
-              "stats": {
-                "x": {
-                  "value": "1"
-                }
-              }
-            }
-          ]
-        },
-        "keywords": {
-          "Tags": [],
-          "Keywords": [
-            "Character",
-            "Command",
-            "M41",
-            "Psyker",
-            "Synapse",
-            "Tervigon"
-          ],
-          "Unit Type": [
-            "Monster"
-          ],
-          "Faction": [
-            "Tyranids"
-          ],
-          "Role": [
-            "HQ"
-          ]
-        },
-        "removed": {
-          "stats": {}
-        },
-        "stats": {
-          "Attacks (A)": {
-            "value": 3
-          },
-          "Ballistic Skill (BS)": {
-            "value": 3
-          },
-          "Initiative (I)": {
-            "value": 3
-          },
-          "Leadership (Ld)": {
-            "value": 9
-          },
-          "Loadout": {
-            "dynamic": true,
-            "ranks": {
-              "Monstrous Scything Talons": {
-                "order": 0,
-                "traits": [
-                  {
-                    "trait": "Melee Weapon§Monstrous Scything Talons"
-                  }
-                ]
-              },
-              "Monstrous Crushing Claws": {
-                "order": 1,
-                "tracking": {
-                  "Points": 15
-                },
-                "traits": [
-                  {
-                    "trait": "Melee Weapon§Monstrous Crushing Claws"
-                  }
-                ]
-              }
-            },
-            "statType": "rank",
-            "value": "Monstrous Scything Talons",
-            "visibility": "normal"
-          },
-          "modelCost": {
-            "value": 120
-          },
-          "Movement (M)": {
-            "value": 8
-          },
-          "Points": {
-            "value": 120
-          },
-          "Save (Sv)": {
-            "value": 3
-          },
-          "Strength (S)": {
-            "value": 7
-          },
-          "Toughness (T)": {
-            "value": 8
-          },
-          "Weapon Skill (WS)": {
-            "value": 3
-          },
-          "Wounds (W)": {
-            "value": 5
           }
         }
       },
@@ -6780,9 +6893,7 @@
       },
       "Wargear§Spine Maw": {
         "keywords": {
-          "Keywords": [
-            "Tyranid Special Rule"
-          ]
+          "Keywords": []
         },
         "text": "At the end of the Combat Phase, select a single enemy infantry type model within 1” of this model. The chosen\nunit must make a Strength test. To make a Strength test, roll a D6 and compare the result to the models Strength (S)\ncharacteristic. If the result is lower than the models Strength (S) characteristic, the test is passed, and the model resists\nbeing placed in the maw. If the result tis higher than the models Strength (S) characteristic, the target model is slain (this\ncounts as an Instant death attack)."
       },
@@ -6791,6 +6902,30 @@
       },
       "Wargear§Tusks": {
         "text": "A model equipped with Tusks may re-roll Hammer of Wrath Attacks."
+      },
+      "Warlord Trait§Alien Cunning": {
+        "keywords": {
+          "Keywords": [
+            "Warlord Trait"
+          ]
+        },
+        "text": "If your army includes a model with this\nwarlord trait, you can select up to 2\nfriendly Tyranid units in your army.\nThey gain the Scout Special rule\nduring deployment."
+      },
+      "Warlord Trait§Heightened Senses": {
+        "keywords": {
+          "Keywords": [
+            "Warlord Trait"
+          ]
+        },
+        "text": "A model with this Warlord trait\ncan always set to Overwatch,\neven if it makes shooting attacks\nin the shooting phase."
+      },
+      "Warlord Trait§Synaptic Linchpin": {
+        "keywords": {
+          "Keywords": [
+            "Warlord Trait"
+          ]
+        },
+        "text": "Extend the range of the Synapse rule\na model with this Warlord Trait has to\n24”. If they do not have the Synapse\nrule, they gain the Synapse special\nrule."
       }
     },
     "gameModes": {},

--- a/Warhammer_40k-_The_Long_War_WH40k-TLW.rulebook
+++ b/Warhammer_40k-_The_Long_War_WH40k-TLW.rulebook
@@ -10,6 +10,36 @@
   "rulebook": {
     "assetTaxonomy": {
       "Character": {
+        "stats": {
+          "Relic": {
+            "statType": "term",
+            "value": "n/a",
+            "visibility": "normal"
+          },
+          "Warlord": {
+            "ranks": {
+              "No": {
+                "order": 0
+              },
+              "Yes": {
+                "order": 1
+              }
+            },
+            "statType": "rank",
+            "value": "No",
+            "visibility": "normal"
+          },
+          "Warlord Trait": {
+            "statType": "term",
+            "value": "n/a",
+            "visibility": "normal"
+          },
+          "Warlord Trait 2": {
+            "statType": "term",
+            "value": "n/a",
+            "visibility": "normal"
+          }
+        },
         "templateClass": "Unit"
       },
       "Melee Weapon": {


### PR DESCRIPTION
-Removed Tervigon from Unit class
-Added Tervigon to Character class.
-Added point costs to Rupture Cannon on Tyrannofex. -Added rules for warlord traits
-Added ability to take warlord traits on Tervigon, more functionality will be added later.
-Removed Redundant 2x scything talons from Carnifex Wargear.