### PR TITLE
Wip ROW Implementation - Moved Lictor and Malanthrope

### DIFF
--- a/Warhammer_40k-_The_Long_War_W40k-TLW_Tyranids.rulebook
+++ b/Warhammer_40k-_The_Long_War_W40k-TLW_Tyranids.rulebook
@@ -1,5 +1,5 @@
 {
-  "name": "W40k:TLW Tyranids",
+  "name": "W40k:TLW Tyranids (outdated)",
   "revision": "0.0.1",
   "game": "Warhammer 40k: The Long War",
   "genre": "sci-fi",
@@ -9,10 +9,10 @@
   "wip": true,
   "dependencies": [
     {
-      "slug": "4Q2YFB",
+      "slug": "8GU2DM",
       "name": "WH40k:TLW",
       "game": "Warhammer 40k: The Long War",
-      "source": ""
+      "source": "https://raw.githubusercontent.com/teacup122/WH40k-TLW-Tyranids/WIP-ROW-Implementation/Warhammer_40k-_The_Long_War_WH40k-TLW.rulebook"
     }
   ],
   "rulebook": {
@@ -2856,6 +2856,41 @@
           }
         }
       },
+      "Rite of War§Assault Wave": {
+        "keywords": {
+          "Keywords": [
+            "Tyranid Rite of War"
+          ]
+        }
+      },
+      "Rite of War§Chitinous Armoured Spearhead": {
+        "keywords": {
+          "Keywords": [
+            "Tyranid Rite of War"
+          ]
+        }
+      },
+      "Rite of War§Feeder Wave": {
+        "keywords": {
+          "Keywords": [
+            "Tyranid Rite of War"
+          ]
+        }
+      },
+      "Rite of War§Sky Swarm Assault": {
+        "keywords": {
+          "Keywords": [
+            "Tyranid Rite of War"
+          ]
+        }
+      },
+      "Rite of War§Subterranean Attack Wave": {
+        "keywords": {
+          "Keywords": [
+            "Tyranid Rite of War"
+          ]
+        }
+      },
       "Rite of War§Vanguard Wave": {
         "keywords": {
           "Keywords": [
@@ -2892,7 +2927,7 @@
                 ]
               }
             },
-            "value": "Vanguard Wave"
+            "value": "-"
           }
         }
       },
@@ -3258,33 +3293,19 @@
           ]
         },
         "rules": {
-          "detectROWVanWave": {
+          "detectROWVanWaveGenestealers": {
             "actions": [
-              {
-                "actionType": "remove",
-                "iterations": 1,
-                "paths": [
-                  [
-                    "{self}",
-                    "keywords",
-                    "Role"
-                  ]
-                ],
-                "prepend": "",
-                "value": "Elites"
-              },
               {
                 "actionType": "add",
                 "iterations": 1,
                 "paths": [
                   [
                     "{self}",
-                    "keywords",
-                    "Role"
+                    "traits"
                   ]
                 ],
                 "prepend": "",
-                "value": "Troops"
+                "value": "Special Rule§Deep Strike"
               }
             ],
             "evals": [

--- a/Warhammer_40k-_The_Long_War_W40k-TLW_Tyranids.rulebook
+++ b/Warhammer_40k-_The_Long_War_W40k-TLW_Tyranids.rulebook
@@ -1,5 +1,5 @@
 {
-  "name": "W40k:TLW Tyranids (outdated)",
+  "name": "W40k:TLW Tyranids",
   "revision": "0.0.1",
   "game": "Warhammer 40k: The Long War",
   "genre": "sci-fi",

--- a/Warhammer_40k-_The_Long_War_W40k-TLW_Tyranids.rulebook
+++ b/Warhammer_40k-_The_Long_War_W40k-TLW_Tyranids.rulebook
@@ -9,8 +9,8 @@
   "wip": true,
   "dependencies": [
     {
-      "slug": "4Q2YFB",
-      "name": "WH40k:TLW",
+      "slug": "SMHB4M",
+      "name": "WH40k:TLW (outdated)",
       "game": "Warhammer 40k: The Long War",
       "source": ""
     }
@@ -1466,6 +1466,43 @@
           }
         }
       },
+      "Model§Von Ryan's Leaper": {
+        "stats": {
+          "Attacks (A)": {
+            "value": 1
+          },
+          "Ballistic Skill (BS)": {
+            "value": 4
+          },
+          "Initiative (I)": {
+            "value": 4
+          },
+          "Leadership (Ld)": {
+            "value": 7
+          },
+          "Movement (M)": {
+            "value": 6
+          },
+          "Points": {
+            "value": 24
+          },
+          "Save (Sv)": {
+            "value": 4
+          },
+          "Strenght (S)": {
+            "value": 4
+          },
+          "Toughness (T)": {
+            "value": 4
+          },
+          "Weapon Skill (WS)": {
+            "value": 4
+          },
+          "Wounds (W)": {
+            "value": 2
+          }
+        }
+      },
       "Model§Zoanthrope": {
         "assets": {
           "traits": [
@@ -2333,6 +2370,13 @@
         }
       },
       "Roster§Roster": {
+        "removed": {
+          "allowed": {
+            "classifications": [
+              "Rite of War"
+            ]
+          }
+        },
         "stats": {
           "Faction": {
             "dynamic": false,
@@ -2342,6 +2386,18 @@
               }
             },
             "value": "Tyranids"
+          },
+          "Rite of War": {
+            "ranks": {
+              "Vanguard Wave": {
+                "order": 1,
+                "traits": [
+                  {
+                    "trait": "Rite of War§Vanguard Wave"
+                  }
+                ]
+              }
+            }
           }
         }
       },
@@ -2558,6 +2614,57 @@
             "Troops"
           ]
         },
+        "rules": {
+          "detectROWVanWave": {
+            "actions": [
+              {
+                "actionType": "remove",
+                "iterations": 1,
+                "paths": [
+                  [
+                    "{self}",
+                    "keywords",
+                    "Role"
+                  ]
+                ],
+                "prepend": "",
+                "value": "Elites"
+              },
+              {
+                "actionType": "add",
+                "iterations": 1,
+                "paths": [
+                  [
+                    "{self}",
+                    "keywords",
+                    "Role"
+                  ]
+                ],
+                "prepend": "",
+                "value": "Troops"
+              }
+            ],
+            "evals": [
+              {
+                "actionable": true,
+                "contains": true,
+                "not": false,
+                "operator": "AND",
+                "paths": [
+                  [
+                    "{roster}",
+                    "stats",
+                    "Rite of War",
+                    "value"
+                  ]
+                ],
+                "value": "Vanguard Wave"
+              }
+            ],
+            "evaluate": "AND",
+            "failState": "pass"
+          }
+        },
         "stats": {
           "Genestealer": {
             "max": 20,
@@ -2569,6 +2676,11 @@
           },
           "Points": {
             "value": 30
+          },
+          "Rite of War": {
+            "statType": "term",
+            "value": null,
+            "visibility": "always"
           }
         }
       },
@@ -3242,6 +3354,110 @@
         },
         "stats": {
           "Tyranid Warrior": {
+            "max": 9,
+            "min": 3,
+            "statType": "numeric",
+            "tracked": true,
+            "value": 0,
+            "visibility": "normal"
+          }
+        }
+      },
+      "Unit§Von Ryan's Leapers": {
+        "allowed": {
+          "items": [
+            "Model§Von Ryan's Leaper"
+          ]
+        },
+        "assets": {
+          "included": [
+            {
+              "item": "Model§Von Ryan's Leaper",
+              "quantity": 3
+            }
+          ],
+          "traits": [
+            "Special Rule§Shadow in the Warp",
+            "Special Rule§The Swarm Descends",
+            "Special Rule§Adaptive Physiology",
+            "Special Rule§Bulky",
+            "Special Rule§Sprint",
+            "Special Rule§Infiltrate"
+          ]
+        },
+        "keywords": {
+          "Role": [
+            "Elites"
+          ],
+          "Unit Type": [
+            "Infantry"
+          ],
+          "Faction": [
+            "Tyranids"
+          ],
+          "Keywords": [
+            "M41",
+            "Tyranids",
+            "Vanguard",
+            "Von Ryan's Leapers"
+          ]
+        },
+        "rules": {
+          "detectROWVanWaveLeapers": {
+            "actions": [
+              {
+                "actionType": "remove",
+                "iterations": 1,
+                "paths": [
+                  [
+                    "{self}",
+                    "keywords",
+                    "Role"
+                  ]
+                ],
+                "prepend": "",
+                "value": "Elites"
+              },
+              {
+                "actionType": "add",
+                "iterations": 1,
+                "paths": [
+                  [
+                    "{self}",
+                    "keywords",
+                    "Role"
+                  ]
+                ],
+                "prepend": "",
+                "value": "Troops"
+              }
+            ],
+            "evals": [
+              {
+                "actionable": true,
+                "contains": true,
+                "not": false,
+                "operator": "AND",
+                "paths": [
+                  [
+                    "{roster}",
+                    "stats",
+                    "Rite of War",
+                    "value"
+                  ]
+                ],
+                "value": "Vanguard Wave"
+              }
+            ],
+            "evaluate": "AND",
+            "failState": "pass"
+          }
+        },
+        "stats": {
+          "Points": {
+            "value": 18
+          },
+          "Von Ryan's Leaper": {
             "max": 9,
             "min": 3,
             "statType": "numeric",

--- a/Warhammer_40k-_The_Long_War_W40k-TLW_Tyranids.rulebook
+++ b/Warhammer_40k-_The_Long_War_W40k-TLW_Tyranids.rulebook
@@ -9,7 +9,7 @@
   "wip": true,
   "dependencies": [
     {
-      "slug": "C8HYTC",
+      "slug": "AKPGJN",
       "name": "WH40k:TLW",
       "game": "Warhammer 40k: The Long War",
       "source": "https://raw.githubusercontent.com/teacup122/WH40k-TLW-Tyranids/main/Warhammer_40k-_The_Long_War_WH40k-TLW.rulebook"
@@ -235,6 +235,129 @@
           },
           "Warlord Trait 2": {
             "dynamic": true
+          }
+        }
+      },
+      "Character§Lictor": {
+        "allowed": {
+          "items": [
+            "Model§Lictor"
+          ]
+        },
+        "assets": {
+          "included": [
+            "Model§Lictor"
+          ],
+          "traits": [
+            "Special Rule§Shadow in the Warp",
+            "Special Rule§The Swarm Descends",
+            "Special Rule§Adaptive Physiology",
+            "Special Rule§Infiltrate",
+            "Special Rule§Outflank",
+            "Special Rule§Move Through Cover",
+            {
+              "item": "Special Rule§Fear",
+              "stats": {
+                "x": {
+                  "value": "2"
+                }
+              }
+            },
+            {
+              "item": "Special Rule§Bulky",
+              "stats": {
+                "x": {
+                  "value": "3"
+                }
+              }
+            },
+            "Special Rule§Pheromone Trail",
+            "Special Rule§Chameleonic"
+          ]
+        },
+        "keywords": {
+          "Keywords": [
+            "Character",
+            "Lictor",
+            "M41",
+            "Tyranids",
+            "Vanguard"
+          ],
+          "Role": [
+            "Elites"
+          ],
+          "Faction": [
+            "Tyranids"
+          ],
+          "Unit Type": [
+            "Infantry"
+          ]
+        },
+        "stats": {
+          "Lictor": {
+            "statType": "numeric",
+            "tracked": true,
+            "value": 0,
+            "visibility": "normal"
+          }
+        }
+      },
+      "Character§Malanthrope": {
+        "allowed": {
+          "items": [
+            "Model§Malanthrope"
+          ]
+        },
+        "assets": {
+          "included": [
+            "Model§Malanthrope"
+          ],
+          "traits": [
+            "Special Rule§Synapse",
+            "Special Rule§Shadow in the Warp",
+            "Special Rule§The Swarm Descends",
+            "Special Rule§Adaptive Physiology",
+            "Special Rule§Preferred Enemy",
+            {
+              "item": "Special Rule§Bulky",
+              "stats": {
+                "x": {
+                  "value": "3"
+                }
+              }
+            },
+            "Special Rule§Shrouding Spores",
+            "Special Rule§Toxic Miasma"
+          ]
+        },
+        "keywords": {
+          "Keywords": [
+            "Character",
+            "Feeder",
+            "Fly",
+            "M41",
+            "Malanthrope",
+            "Synapse",
+            "Tyranids"
+          ],
+          "Role": [
+            "Elites"
+          ],
+          "Faction": [
+            "Tyranids"
+          ],
+          "Unit Type": [
+            "Infantry"
+          ]
+        },
+        "stats": {
+          "Malanthrope": {
+            "max": 1,
+            "min": 1,
+            "statType": "numeric",
+            "tracked": true,
+            "value": 0,
+            "visibility": "normal"
           }
         }
       },
@@ -5441,11 +5564,53 @@
         "allowed": {
           "classifications": []
         },
+        "constraints": {
+          "none": []
+        },
         "removed": {
           "allowed": {
             "classifications": [
               "Rite of War"
             ]
+          }
+        },
+        "rules": {
+          "NoVanguardKeywordInFeederWave": {
+            "actions": [
+              {
+                "actionType": "add",
+                "iterations": 1,
+                "paths": [
+                  [
+                    "{self}",
+                    "constraints",
+                    "none"
+                  ]
+                ],
+                "prepend": "",
+                "value": "Vanguard"
+              }
+            ],
+            "evals": [
+              {
+                "actionable": true,
+                "contains": true,
+                "not": false,
+                "operator": "AND",
+                "paths": [
+                  [
+                    "{self}",
+                    "stats",
+                    "Rite of War",
+                    "value"
+                  ]
+                ],
+                "value": "Feeder Wave"
+              }
+            ],
+            "evaluate": "AND",
+            "failState": "pass",
+            "order": 1
           }
         },
         "stats": {
@@ -6686,65 +6851,6 @@
           }
         }
       },
-      "Unit§Malanthrope": {
-        "allowed": {
-          "items": [
-            "Model§Malanthrope"
-          ]
-        },
-        "assets": {
-          "included": [
-            "Model§Malanthrope"
-          ],
-          "traits": [
-            "Special Rule§Synapse",
-            "Special Rule§Shadow in the Warp",
-            "Special Rule§The Swarm Descends",
-            "Special Rule§Adaptive Physiology",
-            "Special Rule§Preferred Enemy",
-            {
-              "item": "Special Rule§Bulky",
-              "stats": {
-                "x": {
-                  "value": "3"
-                }
-              }
-            },
-            "Special Rule§Shrouding Spores",
-            "Special Rule§Toxic Miasma"
-          ]
-        },
-        "keywords": {
-          "Keywords": [
-            "Character",
-            "Feeder",
-            "Fly",
-            "M41",
-            "Malanthrope",
-            "Synapse",
-            "Tyranids"
-          ],
-          "Role": [
-            "Elites"
-          ],
-          "Faction": [
-            "Tyranids"
-          ],
-          "Unit Type": [
-            "Infantry"
-          ]
-        },
-        "stats": {
-          "Malanthrope": {
-            "max": 1,
-            "min": 1,
-            "statType": "numeric",
-            "tracked": true,
-            "value": 0,
-            "visibility": "normal"
-          }
-        }
-      },
       "Unit§Maleceptor": {
         "allowed": {
           "items": [
@@ -7702,19 +7808,6 @@
         "rules": {
           "detectROWVanWaveLeapers": {
             "actions": [
-              {
-                "actionType": "remove",
-                "iterations": 1,
-                "paths": [
-                  [
-                    "{self}",
-                    "keywords",
-                    "Role"
-                  ]
-                ],
-                "prepend": "",
-                "value": "Elites"
-              },
               {
                 "actionType": "add",
                 "iterations": 1,

--- a/Warhammer_40k-_The_Long_War_W40k-TLW_Tyranids.rulebook
+++ b/Warhammer_40k-_The_Long_War_W40k-TLW_Tyranids.rulebook
@@ -28,7 +28,58 @@
           }
         }
       },
-      "Unit": {}
+      "Unit": {
+        "rules": {
+          "DetectROWAssaultWaveMonsters": {
+            "actions": [
+              {
+                "actionType": "add",
+                "iterations": 1,
+                "paths": [
+                  [
+                    "{self}",
+                    "traits"
+                  ]
+                ],
+                "value": "Special Rule§Outflank"
+              }
+            ],
+            "evals": [
+              {
+                "actionable": true,
+                "contains": true,
+                "not": false,
+                "operator": "AND",
+                "paths": [
+                  [
+                    "{roster}",
+                    "stats",
+                    "Rite of War",
+                    "value"
+                  ]
+                ],
+                "value": "Assault Wave"
+              },
+              {
+                "actionable": true,
+                "contains": true,
+                "not": false,
+                "operator": "AND",
+                "paths": [
+                  [
+                    "{self}",
+                    "keywords",
+                    "Unit Type"
+                  ]
+                ],
+                "value": "Monster"
+              }
+            ],
+            "evaluate": "AND",
+            "failState": "pass"
+          }
+        }
+      }
     },
     "assetCatalog": {
       "Adaptive Physiology§Adrenal Glands": {
@@ -2925,9 +2976,48 @@
                     "trait": "Rite of War§Vanguard Wave"
                   }
                 ]
+              },
+              "Assault Wave": {
+                "order": 2,
+                "traits": [
+                  {
+                    "trait": "Rite of War§Assault Wave"
+                  }
+                ]
+              },
+              "Feeder Wave": {
+                "order": 3,
+                "traits": [
+                  {
+                    "trait": "Rite of War§Feeder Wave"
+                  }
+                ]
+              },
+              "Chitinous Armoured Spearhead": {
+                "order": 4,
+                "traits": [
+                  {
+                    "trait": "Rite of War§Chitinous Armoured Spearhead"
+                  }
+                ]
+              },
+              "Subterranean Attack Wave": {
+                "order": 5,
+                "traits": [
+                  {
+                    "trait": "Rite of War§Subterranean Attack Wave"
+                  }
+                ]
+              },
+              "Sky Swarm Assault": {
+                "order": 6,
+                "traits": [
+                  {
+                    "trait": "Rite of War§Sky Swarm Assault"
+                  }
+                ]
               }
-            },
-            "value": "-"
+            }
           }
         }
       },

--- a/Warhammer_40k-_The_Long_War_WH40k-TLW.rulebook
+++ b/Warhammer_40k-_The_Long_War_WH40k-TLW.rulebook
@@ -404,7 +404,8 @@
       "Roster§Roster": {
         "allowed": {
           "classifications": [
-            "Unit"
+            "Unit",
+            "Rite of War"
           ]
         },
         "aspects": {
@@ -431,6 +432,18 @@
             "tracked": true,
             "value": 0,
             "visibility": "normal"
+          },
+          "Rite of War": {
+            "dynamic": true,
+            "ranks": {
+              "-": {
+                "order": 0
+              }
+            },
+            "statType": "rank",
+            "tracked": true,
+            "value": "-",
+            "visibility": "always"
           }
         }
       },


### PR DESCRIPTION
-Moved Lictor and Malanthrope to Character Class
-Added rule to forbid Vanguard units from being taken on Feeder wave ROW